### PR TITLE
merkle/depth irrelevance

### DIFF
--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	emptyNodeTag byte = 0
-	innerNodeTag byte = 1
-	leafNodeTag  byte = 2
+	leafNodeTag  byte = 1
+	innerNodeTag byte = 2
 )
 
 type Tree struct {


### PR DESCRIPTION
- **merkle lib no longer bakes in any assumptions about the depth of nodes. strategy: make all loops infinite, and make getBit always return smth**
- **x**
