### PR TITLE
merkle/prove sibs

### DIFF
--- a/etc/ci-check.py
+++ b/etc/ci-check.py
@@ -17,6 +17,17 @@ class Tests(unittest.TestCase):
             f"Command failed with error message: {res.stderr} and output: {res.stdout}",
         )
 
+    def test_merkle_serde_compiled(self):
+        cmd = "go run ./serde --in merkle/serde.go && git diff --exit-code merkle/serde.out.go"
+        res = subprocess.run(
+            cmd, cwd=proj_root, shell=True, capture_output=True, text=True
+        )
+        self.assertEqual(
+            res.returncode,
+            0,
+            f"Command failed with error message: {res.stderr} and output: {res.stdout}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/kt/auditor.go
+++ b/kt/auditor.go
@@ -71,11 +71,11 @@ func checkUpd(keys *merkle.Tree, nextEp uint64, upd map[string][]byte) bool {
 
 // checkOneUpd checks that an update is safe to apply, and errs on fail.
 func checkOneUpd(keys *merkle.Tree, nextEp uint64, mapLabel, mapVal []byte) bool {
-	inTree, _, err0 := keys.Get(mapLabel)
-	// label has right len. used in applyUpd.
-	if err0 {
+	// used in applyUpd.
+	if uint64(len(mapLabel)) != cryptoffi.HashLen {
 		return true
 	}
+	inTree, _ := keys.Get(mapLabel)
 	// label not already in keyMap. map monotonicity.
 	if inTree {
 		return true

--- a/kt/server.go
+++ b/kt/server.go
@@ -236,12 +236,10 @@ func (s *Server) mapper0(in *WQReq, out *mapper0Out) {
 
 // mapper1 computes merkle proofs and assembles full response.
 func (s *Server) mapper1(in *mapper0Out, out *WQResp) {
-	latIn, _, latMerk, err0 := s.keyMap.Prove(in.latestVrfHash)
-	std.Assert(!err0)
+	latIn, _, latMerk := s.keyMap.Prove(in.latestVrfHash)
 	std.Assert(latIn)
 
-	boundIn, _, boundMerk, err1 := s.keyMap.Prove(in.boundVrfHash)
-	std.Assert(!err1)
+	boundIn, _, boundMerk := s.keyMap.Prove(in.boundVrfHash)
 	std.Assert(!boundIn)
 
 	out.Dig = getDig(s.epochHist)
@@ -329,8 +327,7 @@ func getHist(keyMap *merkle.Tree, uid, numVers uint64, vrfSk *cryptoffi.VrfPriva
 	var hist = make([]*MembHide, 0, numVers-1)
 	for ver := uint64(0); ver < numVers-1; ver++ {
 		label, labelProof := compMapLabel(uid, ver, vrfSk)
-		inMap, mapVal, mapProof, err0 := keyMap.Prove(label)
-		std.Assert(!err0)
+		inMap, mapVal, mapProof := keyMap.Prove(label)
 		std.Assert(inMap)
 		hist = append(hist, &MembHide{LabelProof: labelProof, MapVal: mapVal, MerkleProof: mapProof})
 	}
@@ -344,8 +341,7 @@ func getLatest(keyMap *merkle.Tree, uid, numVers uint64, vrfSk *cryptoffi.VrfPri
 		return false, &Memb{PkOpen: &CommitOpen{}}
 	}
 	label, labelProof := compMapLabel(uid, numVers-1, vrfSk)
-	inMap, mapVal, mapProof, err0 := keyMap.Prove(label)
-	std.Assert(!err0)
+	inMap, mapVal, mapProof := keyMap.Prove(label)
 	std.Assert(inMap)
 	valPre, _, err1 := MapValPreDecode(mapVal)
 	std.Assert(!err1)
@@ -357,8 +353,7 @@ func getLatest(keyMap *merkle.Tree, uid, numVers uint64, vrfSk *cryptoffi.VrfPri
 // getBound returns a non-membership proof for the boundary version.
 func getBound(keyMap *merkle.Tree, uid, numVers uint64, vrfSk *cryptoffi.VrfPrivateKey) *NonMemb {
 	label, labelProof := compMapLabel(uid, numVers, vrfSk)
-	inMap, _, mapProof, err0 := keyMap.Prove(label)
-	std.Assert(!err0)
+	inMap, _, mapProof := keyMap.Prove(label)
 	std.Assert(!inMap)
 	return &NonMemb{LabelProof: labelProof, MerkleProof: mapProof}
 }

--- a/merkle/bench_test.go
+++ b/merkle/bench_test.go
@@ -44,10 +44,7 @@ func TestBenchMerkGet(t *testing.T) {
 	start := time.Now()
 	for i := 0; i < nOps; i++ {
 		l := labels[rand.Uint64N(defNSeed)]
-		isReg, _, errb := tr.Get(l)
-		if errb {
-			t.Fatal()
-		}
+		isReg, _ := tr.Get(l)
 		if !isReg {
 			t.Fatal()
 		}
@@ -72,10 +69,7 @@ func TestBenchMerkGenVer(t *testing.T) {
 		l := labels[rand.Uint64N(defNSeed)]
 
 		t0 := time.Now()
-		isReg, v, p, errb := tr.Prove(l)
-		if errb {
-			t.Fatal()
-		}
+		isReg, v, p := tr.Prove(l)
 		if !isReg {
 			t.Fatal()
 		}
@@ -104,10 +98,7 @@ func TestBenchMerkSize(t *testing.T) {
 	tr, labels := seedTree(t, defNSeed)
 	samp := &stats.Sample{Xs: make([]float64, 0, defNSeed)}
 	for _, label := range labels {
-		isReg, _, p, errb := tr.Prove(label)
-		if errb {
-			t.Fatal()
-		}
+		isReg, _, p := tr.Prove(label)
 		if !isReg {
 			t.Fatal()
 		}

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -171,12 +171,15 @@ func getProofLen(depth uint64) uint64 {
 
 // Verify verifies proof against the tree rooted at dig
 // and returns an error upon failure.
-// there are two types of inputs.
+// there are two types of inputs:
 // if inTree, (label, val) should be in the tree.
 // if !inTree, label should not be in the tree.
 func Verify(inTree bool, label, val, proof, dig []byte) bool {
 	proofDec, _, err0 := MerkleProofDecode(proof)
 	if err0 {
+		return true
+	}
+	if proofDec.FoundOtherLeaf && std.BytesEqual(label, proofDec.LeafLabel) {
 		return true
 	}
 
@@ -186,9 +189,6 @@ func Verify(inTree bool, label, val, proof, dig []byte) bool {
 		lastHash = compLeafHash(label, val)
 	} else {
 		if proofDec.FoundOtherLeaf {
-			if std.BytesEqual(label, proofDec.LeafLabel) {
-				return true
-			}
 			lastHash = compLeafHash(proofDec.LeafLabel, proofDec.LeafVal)
 		} else {
 			lastHash = compEmptyHash()

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -131,11 +131,11 @@ func (t *Tree) prove(label []byte, prove bool) (bool, []byte, []byte, bool) {
 	if prove {
 		primitive.UInt64Put(proof, uint64(len(proof))-8) // SibsLen
 	}
-	inTree, val, proof0 := proveSibs(label, prove, n, proof)
+	inTree, val, proof0 := proveLast(label, prove, n, proof)
 	return inTree, val, proof0, false
 }
 
-func proveSibs(label []byte, prove bool, last *node, proof []byte) (bool, []byte, []byte) {
+func proveLast(label []byte, prove bool, last *node, proof []byte) (bool, []byte, []byte) {
 	// empty node.
 	if last == nil {
 		if prove {

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -141,19 +141,19 @@ func (t *Tree) prove(label []byte, getProof bool) (bool, []byte, []byte, bool) {
 func find(label []byte, getProof bool, ctx *context, n *node, depth uint64) ([]byte, []byte, []byte) {
 	// break on empty node.
 	if n == nil {
+		var proof []byte
 		if getProof {
-			var proof = make([]byte, 8, getProofLen(depth))
-			return nil, nil, proof
+			proof = make([]byte, 8, getProofLen(depth))
 		}
-		return nil, nil, nil
+		return nil, nil, proof
 	}
 	// break on leaf node.
 	if n.child0 == nil && n.child1 == nil {
+		var proof []byte
 		if getProof {
-			var proof = make([]byte, 8, getProofLen(depth))
-			return n.label, n.val, proof
+			proof = make([]byte, 8, getProofLen(depth))
 		}
-		return n.label, n.val, nil
+		return n.label, n.val, proof
 	}
 
 	child, sib := getChild(n, label, depth)

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -133,7 +133,7 @@ func (t *Tree) prove(label []byte, getProof bool) (bool, []byte, []byte) {
 	return true, foundVal, proof
 }
 
-// find returns whether label path found (and if so, the found label and val)
+// find returns whether label path was found (and if so, the found label and val)
 // and the sibling proof.
 func find(label []byte, getProof bool, ctx *context, n *node, depth uint64) (bool, []byte, []byte, []byte) {
 	// break on empty node.

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -76,10 +76,7 @@ func TestMap(t *testing.T) {
 }
 
 func proveAndVerify(t *testing.T, tr *Tree, label []byte, expInTree bool, expVal []byte) {
-	inTree, val, proof, errb := tr.Prove(label)
-	if errb {
-		t.Fatal()
-	}
+	inTree, val, proof := tr.Prove(label)
 	if inTree != expInTree {
 		t.Fatal()
 	}
@@ -87,7 +84,7 @@ func proveAndVerify(t *testing.T, tr *Tree, label []byte, expInTree bool, expVal
 		t.Fatal()
 	}
 	dig := tr.Digest()
-	errb = Verify(inTree, label, val, proof, dig)
+	errb := Verify(inTree, label, val, proof, dig)
 	if errb {
 		t.Fatal()
 	}

--- a/merkle/serde.go
+++ b/merkle/serde.go
@@ -3,7 +3,7 @@ package merkle
 // Proof has non-nil leaf data for non-membership proofs
 // that terminate in a different leaf.
 type MerkleProof struct {
-	Siblings  []byte
 	LeafLabel []byte
 	LeafVal   []byte
+	Siblings  []byte
 }

--- a/merkle/serde.go
+++ b/merkle/serde.go
@@ -1,9 +1,10 @@
 package merkle
 
-// Proof has non-nil leaf data for non-membership proofs
+// MerkleProof has non-nil leaf data for non-membership proofs
 // that terminate in a different leaf.
 type MerkleProof struct {
-	Siblings  []byte
-	LeafLabel []byte
-	LeafVal   []byte
+	Siblings       []byte
+	FoundOtherLeaf bool
+	LeafLabel      []byte
+	LeafVal        []byte
 }

--- a/merkle/serde.go
+++ b/merkle/serde.go
@@ -3,7 +3,7 @@ package merkle
 // Proof has non-nil leaf data for non-membership proofs
 // that terminate in a different leaf.
 type MerkleProof struct {
+	Siblings  []byte
 	LeafLabel []byte
 	LeafVal   []byte
-	Siblings  []byte
 }

--- a/merkle/serde.out.go
+++ b/merkle/serde.out.go
@@ -19,5 +19,5 @@ func MerkleProofDecode(b0 []byte) (*MerkleProof, []byte, bool) {
 	if err3 {
 		return nil, nil, true
 	}
-	return &MerkleProof{LeafLabel: a1, LeafVal: a2, Siblings: a3}, b3, false
+	return &MerkleProof{Siblings: a1, LeafLabel: a2, LeafVal: a3}, b3, false
 }

--- a/merkle/serde.out.go
+++ b/merkle/serde.out.go
@@ -4,14 +4,23 @@ package merkle
 
 import (
 	"github.com/mit-pdos/pav/marshalutil"
+	"github.com/tchajed/marshal"
 )
 
+func MerkleProofEncode(b0 []byte, o *MerkleProof) []byte {
+	var b = b0
+	b = marshalutil.WriteSlice1D(b, o.Siblings)
+	b = marshal.WriteBool(b, o.FoundOtherLeaf)
+	b = marshalutil.WriteSlice1D(b, o.LeafLabel)
+	b = marshalutil.WriteSlice1D(b, o.LeafVal)
+	return b
+}
 func MerkleProofDecode(b0 []byte) (*MerkleProof, []byte, bool) {
 	a1, b1, err1 := marshalutil.ReadSlice1D(b0)
 	if err1 {
 		return nil, nil, true
 	}
-	a2, b2, err2 := marshalutil.ReadSlice1D(b1)
+	a2, b2, err2 := marshalutil.ReadBool(b1)
 	if err2 {
 		return nil, nil, true
 	}
@@ -19,5 +28,9 @@ func MerkleProofDecode(b0 []byte) (*MerkleProof, []byte, bool) {
 	if err3 {
 		return nil, nil, true
 	}
-	return &MerkleProof{Siblings: a1, LeafLabel: a2, LeafVal: a3}, b3, false
+	a4, b4, err4 := marshalutil.ReadSlice1D(b3)
+	if err4 {
+		return nil, nil, true
+	}
+	return &MerkleProof{Siblings: a1, FoundOtherLeaf: a2, LeafLabel: a3, LeafVal: a4}, b4, false
 }

--- a/merkle/serde.out.go
+++ b/merkle/serde.out.go
@@ -6,13 +6,6 @@ import (
 	"github.com/mit-pdos/pav/marshalutil"
 )
 
-func MerkleProofEncode(b0 []byte, o *MerkleProof) []byte {
-	var b = b0
-	b = marshalutil.WriteSlice1D(b, o.Siblings)
-	b = marshalutil.WriteSlice1D(b, o.LeafLabel)
-	b = marshalutil.WriteSlice1D(b, o.LeafVal)
-	return b
-}
 func MerkleProofDecode(b0 []byte) (*MerkleProof, []byte, bool) {
 	a1, b1, err1 := marshalutil.ReadSlice1D(b0)
 	if err1 {
@@ -26,5 +19,5 @@ func MerkleProofDecode(b0 []byte) (*MerkleProof, []byte, bool) {
 	if err3 {
 		return nil, nil, true
 	}
-	return &MerkleProof{Siblings: a1, LeafLabel: a2, LeafVal: a3}, b3, false
+	return &MerkleProof{LeafLabel: a1, LeafVal: a2, Siblings: a3}, b3, false
 }


### PR DESCRIPTION
- **merkle: like verify, separate prove out into sibling proof followed by proof of last node**
- **prove does things in opposite order as verify. helper should actually be called proveLast**
- **merkle.prove recursive sibling-proof impl. easier match to invs. perf basically the same as loop impl, even tho golang doesn't have tail call opt**
- **make proveSiblings precond be own tree (nothing about proof sl), and postcond be proof sl matches tree**
- **compute leaf hash at bottom of recur instead of after recur. this removes having to think about fancy last node ownership of recur func. also, with making proof at bottom of recur, can exactly pre-size it**
- **even simpler Get. recur returns found label and val. wrapper code encodes those into a proof and decides whether they're memb or non-memb**
- **x**
- **explicitly return whether found. in prep for arbitrary labels**
- **allow arbitrary labels in Get, Prove, Verify. Put still checks label len, but for liveness (not safety) reasons**
- **for goose**
- **x**
